### PR TITLE
Fix ccts-cct import schemaLocation in PUF-ExtensionComponent.xsd (ADO 5500737)

### DIFF
--- a/xml-schemas/extensions/PUF-ExtensionComponent.xsd
+++ b/xml-schemas/extensions/PUF-ExtensionComponent.xsd
@@ -8,7 +8,7 @@
     <!-- ===== Imports ===== -->
     <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" schemaLocation="../common/UBL-CommonBasicComponents-2.3.xsd"/>
     <xsd:import namespace="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" schemaLocation="../common/UBL-CommonAggregateComponents-2.3.xsd"/>
-    <xsd:import namespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2" schemaLocation="../common/BDNDR-UnqualifiedDataTypes-1.1.xsd"/>
+    <xsd:import namespace="urn:un:unece:uncefact:data:specification:CoreComponentTypeSchemaModule:2" schemaLocation="../common/BDNDR-CCTS_CCT_SchemaModule-1.1.xsd"/>
     <!-- ===== Element Declarations ===== -->
     <xsd:element name="Amount" type="PUFAmountType"/>
     <xsd:element name="IDType" type="PUFIDType"/>


### PR DESCRIPTION
`PUF-ExtensionComponent.xsd` imported the `CoreComponentTypeSchemaModule:2` namespace but set `schemaLocation` to `BDNDR-UnqualifiedDataTypes-1.1.xsd`, whose `targetNamespace` differs. Repointed to `BDNDR-CCTS_CCT_SchemaModule-1.1.xsd`, which matches the imported namespace. No instance or wire-format change.